### PR TITLE
Add "blur all except matching" option

### DIFF
--- a/contents/config/main.xml
+++ b/contents/config/main.xml
@@ -6,10 +6,16 @@
   <kcfgfile name=""/>
   <group name="">
     <entry name="patterns" type="String">
-	    <label>Comma-separated list of window classes</label>
-      <default>yakuake
+      <label>Comma-separated list of window classes</label>
+        <default>yakuake
 urxvt
 keepassxc</default>
+    </entry>
+    <entry name="blurMatching" type="Bool">
+      <default>true</default>
+    </entry>
+    <entry name="blurExceptMatching" type="Bool">
+      <default>false</default>
     </entry>
   </group>
 </kcfg>

--- a/contents/ui/config.ui
+++ b/contents/ui/config.ui
@@ -7,7 +7,7 @@
     <x>0</x>
     <y>0</y>
     <width>400</width>
-    <height>400</height>
+    <height>451</height>
    </rect>
   </property>
   <property name="windowTitle">
@@ -27,8 +27,40 @@
    <item>
     <widget class="QPlainTextEdit" name="kcfg_patterns"/>
    </item>
+   <item>
+    <widget class="QSplitter" name="splitter">
+     <property name="sizePolicy">
+      <sizepolicy hsizetype="Fixed" vsizetype="Preferred">
+       <horstretch>0</horstretch>
+       <verstretch>0</verstretch>
+      </sizepolicy>
+     </property>
+     <property name="orientation">
+      <enum>Qt::Horizontal</enum>
+     </property>
+     <widget class="QRadioButton" name="kcfg_blurMatching">
+      <property name="text">
+       <string>Blur matching</string>
+      </property>
+      <attribute name="buttonGroup">
+       <string notr="true">matchTypeGroup</string>
+      </attribute>
+     </widget>
+     <widget class="QRadioButton" name="kcfg_blurExceptMatching">
+      <property name="text">
+       <string>Blur all except matching</string>
+      </property>
+      <attribute name="buttonGroup">
+       <string notr="true">matchTypeGroup</string>
+      </attribute>
+     </widget>
+    </widget>
+   </item>
   </layout>
  </widget>
  <resources/>
  <connections/>
+ <buttongroups>
+  <buttongroup name="matchTypeGroup"/>
+ </buttongroups>
 </ui>

--- a/contents/ui/main.qml
+++ b/contents/ui/main.qml
@@ -14,6 +14,10 @@ Item {
             })
     )
 
+    readonly property var blurMatching: (
+        KWin.readConfig("blurMatching", true)
+    )
+
     PlasmaCore.DataSource {
         id: shell
         engine: 'executable'
@@ -35,7 +39,9 @@ Item {
 
         var cls = client.resourceClass.toString().toLowerCase();
         var name = client.resourceName.toString().toLowerCase();
-        if (root.patterns.indexOf(cls) >= 0 || root.patterns.indexOf(name) >= 0) {
+        var clsMatches = root.patterns.indexOf(cls) >= 0 || root.patterns.indexOf(name) >= 0;
+
+        if (clsMatches == root.blurMatching) {
             var wid = "0x" + client.windowId.toString(16);
             shell.run("xprop -f _KDE_NET_WM_BLUR_BEHIND_REGION 32c -set _KDE_NET_WM_BLUR_BEHIND_REGION 0 -id " + wid);
         }


### PR DESCRIPTION
Hello, thanks for providing this excellent script to the community.

This PR adds an option to invert the window matching logic, allowing the user to specify just the windows they *don't* want to blur.

![Screenshot_20190610_154037](https://user-images.githubusercontent.com/11548856/59231710-97399780-8b96-11e9-9679-b47522d1c4a7.png)

Personally I find it very useful.