### PR TITLE
Fix for windows with 0-length class name

### DIFF
--- a/contents/ui/main.qml
+++ b/contents/ui/main.qml
@@ -50,6 +50,9 @@ Item {
             } else {
                 var wid = "0x" + client.windowId.toString(16);
                 shell.run("xprop -f _KDE_NET_WM_BLUR_BEHIND_REGION 32c -set _KDE_NET_WM_BLUR_BEHIND_REGION 0 -id " + wid);
+            } else if (name.length == 0 && !root.blurMatching) {
+                var wid = "0x" + client.windowId.toString(16);
+                shell.run("xprop -f _KDE_NET_WM_BLUR_BEHIND_REGION 32c -set _KDE_NET_WM_BLUR_BEHIND_REGION 0 -id " + wid);
             }
         }
     }


### PR DESCRIPTION
Certain windows (e.g. spotify) for some reason have a 0-length class name upon launch, which means they are not currently targeted by kwin-forceblur when "Blur all except matching" is enabled. This is a fix that specifically checks for windows with an empty class name and applies blur to them if "Blur all except matching" is enabled. Related: #11 